### PR TITLE
Allow changing old answers

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery2
+//= require jquery
 //= require react
 //= require react_ujs
 //= require components

--- a/app/assets/javascripts/components/question_list.coffee
+++ b/app/assets/javascripts/components/question_list.coffee
@@ -19,7 +19,7 @@
             question.text
           ul
             className: 'options'
-            question.answer_option_set.map (answer_option) =>
+            question.answer_option_set.answer_options.map (answer_option) =>
               li
                 className: 'option'
                 key: "question_#{question.key}_answer_#{answer_option.value}"

--- a/app/assets/javascripts/components/screensmart_app.coffee
+++ b/app/assets/javascripts/components/screensmart_app.coffee
@@ -18,7 +18,7 @@
   addAnswerToQuestion: (key, value) ->
     response = @state.response
     questions = response.questions
-    response.questions[@indexOf(key)].answer = { value: value }
+    response.questions[@indexOf(key)].answer_value = value
     @setState(response: response)
 
   removeQuestionsStartingAt: (key) ->
@@ -30,37 +30,30 @@
 
   questionsWithAnswer: ->
     @questions().filter (question) ->
-      question.answer?
+      question.answer_value?
 
   questions: ->
     @state.response.questions
 
   estimate: ->
-    lastQuestionWithAnswer = @questions()[@questions().length - 2]
-    if lastQuestionWithAnswer?
-      lastQuestionWithAnswer.answer.new_estimate
-    else
-      @state.response.initial_estimate
+    @state.response.estimate
 
   variance: ->
-    lastQuestionWithAnswer = @questions()[@questions().length - 2]
-    if lastQuestionWithAnswer?
-      lastQuestionWithAnswer.answer.new_variance
-    else
-      @state.response.initial_variance
+    @state.response.variance
 
-  answerHash: ->
-    answers = {}
+  answerValues: ->
+    answerValues = {}
     @questionsWithAnswer().forEach (question) ->
-      answers[question.key] = question.answer.value
-    answers
+      answerValues[question.key] = parseInt(question.answer_value)
+    answerValues
 
   refreshResponse: ->
     $.ajax '/responses',
       method: 'POST'
       dataType: 'json'
-      data:
-        answers:  @answerHash()
+      contentType: 'application/json'
+      data: JSON.stringify
+        answer_values: @answerValues()
       headers:
         'X-CSRF-Token': @props.csrfToken
     .fail (xhr, status, error) ->

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -1,6 +1,6 @@
 class ResponsesController < ApplicationController
   def create
-    @response = Response.new(answers: params[:answers])
+    @response = Response.new(answer_values: params[:answer_values])
     render json: ResponseSerializer.new(@response).as_json
   end
 end

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -1,6 +1,18 @@
 class ResponsesController < ApplicationController
+  wrap_parameters Response, format: :json
+
   def create
-    @response = Response.new(answer_values: params[:answer_values])
+    @response = Response.new(response_params)
     render json: ResponseSerializer.new(@response).as_json
+  end
+
+  private
+
+  def response_params
+    return unless params[:response]
+
+    params.require(:response).tap do |whitelisted|
+      whitelisted[:answer_values] = params[:response][:answer_values]
+    end
   end
 end

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -1,10 +1,6 @@
 class ResponsesController < ApplicationController
   def create
-    @response = Response.new(response_params)
+    @response = Response.new(answers: params[:answers])
     render json: ResponseSerializer.new(@response).as_json
-  end
-
-  def response_params
-    params.permit(:old_estimate, :old_variance).merge(answers: params[:answers])
   end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,12 @@
+class Answer < BaseModel
+  attr_accessor :key, :value
+
+  validates_inclusion_of :key, in: RPackage.question_keys
+  validates_numericality_of :value, only_integer: true
+
+  def question
+    q = Question.new key: key
+    q.answer_value = value if value.present?
+    q
+  end
+end

--- a/app/models/answer_option.rb
+++ b/app/models/answer_option.rb
@@ -1,5 +1,3 @@
-class AnswerOption
-  include ActiveModel::Model
-  include ActiveModel::Serialization
+class AnswerOption < BaseModel
   attr_accessor :value, :text
 end

--- a/app/models/answer_option_set.rb
+++ b/app/models/answer_option_set.rb
@@ -1,6 +1,4 @@
-class AnswerOptionSet
-  include ActiveModel::Model
-  include ActiveModel::Serialization
+class AnswerOptionSet < BaseModel
   attr_accessor :id, :answer_options
 
   include Enumerable

--- a/app/models/base_model.rb
+++ b/app/models/base_model.rb
@@ -1,0 +1,14 @@
+class BaseModel
+  include ActiveModel::Model
+  include ActiveModel::Serialization
+  include ActiveModel::Validations
+
+  def ensure_valid
+    if valid?
+      yield
+    else
+      raise "#{self.class} must be valid when accessing `#{caller_locations(1, 1)[0].label}`.\n" \
+            "Errors: #{errors.full_messages}"
+    end
+  end
+end

--- a/app/models/base_model.rb
+++ b/app/models/base_model.rb
@@ -7,7 +7,7 @@ class BaseModel
     if valid?
       yield
     else
-      raise "#{self.class} must be valid when accessing `#{caller_locations(1, 1)[0].label}`.\n" \
+      raise "#{self.class} must be valid when accessing R attributes.\n" \
             "Errors: #{errors.full_messages}"
     end
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,25 +1,28 @@
-class Question
-  include ActiveModel::Model
-  include ActiveModel::Serialization
-  attr_accessor :key, :text, :answer_option_set
+class Question < BaseModel
+  attr_accessor :key, :answer_value
 
-  def self.find_by_key(key)
-    all.detect { |question| question.key == key } || raise("question `#{key}` not found")
+  validates_inclusion_of :key, in: RPackage.question_keys
+
+  def text
+    ensure_valid do
+      RPackage.question_by_key(key)['text']
+    end
   end
 
-  def self.parse(raw_question)
-    new \
-      key:  raw_question['key'],
-      text: raw_question['text'],
-      answer_option_set: AnswerOptionSet.new(
-        id: raw_question['answer_option_set_id'],
-        answer_options: raw_question['answer_options'].map do |raw_answer_option|
-          AnswerOption.new(value: raw_answer_option['value'], text: raw_answer_option['text'])
-        end
-      )
+  def answer_option_set
+    AnswerOptionSet.new(
+      id: data_from_r['answer_option_set_id'],
+      answer_options: data_from_r['answer_options'].map do |attributes|
+        AnswerOption.new(attributes)
+      end
+    )
   end
 
-  def self.all
-    RPackage.questions.map { |raw_question| parse(raw_question) }
+  def answer
+    Answer.new key: key, value: answer_value
+  end
+
+  def data_from_r
+    RPackage.question_by_key(key)
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,7 +1,8 @@
 class Question < BaseModel
   attr_accessor :key, :answer_value
 
-  validates_inclusion_of :key, in: RPackage.question_keys
+  validates_inclusion_of :key, in: RPackage.question_keys,
+                               message: '`%{value}` not found'
 
   def text
     ensure_valid do

--- a/app/models/r_package.rb
+++ b/app/models/r_package.rb
@@ -1,9 +1,18 @@
 # Only module that should communicate with screensmart-r.
 module RPackage
+  def self.question_by_key(key)
+    questions.detect { |question| question['key'] == key }
+  end
+
+  def self.question_keys
+    questions.map { |question| question['key'] }
+  end
+
   def self.questions
     call('get_itembank_rdata')
   end
 
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def self.data_for(raw_answers)
     answers = integerize_values(raw_answers)
 
@@ -28,6 +37,7 @@ module RPackage
 
     memo
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def self.integerize_values(raw_answers)
     raw_answers.each_with_object({}) do |(key, value), answers|

--- a/app/models/r_package.rb
+++ b/app/models/r_package.rb
@@ -13,9 +13,7 @@ module RPackage
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-  def self.data_for(raw_answers)
-    answers = integerize_values(raw_answers)
-
+  def self.data_for(answers)
     raw_data = call('call_shadowcat', responses: [])
     memo = { next_question_key: raw_data['key_new_item'],
              estimate: raw_data['estimate'][0].to_f,
@@ -39,12 +37,6 @@ module RPackage
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-  def self.integerize_values(raw_answers)
-    raw_answers.each_with_object({}) do |(key, value), answers|
-      answers[key] = value.to_i
-    end
-  end
-
   def self.call(function, parameters = {})
     Rails.cache.fetch(cache_key_for(function, parameters)) do
       Rails.logger.debug "Calling OpenCPU: #{function}(#{parameters})" # Only log non-cached calls
@@ -54,6 +46,6 @@ module RPackage
   end
 
   def self.cache_key_for(function, parameters)
-    "#{Rails.env}/R/#{function}/#{parameters}"
+    "#{ENV['RAILS_ENV']}/R/#{function}/#{parameters}"
   end
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -4,7 +4,7 @@
 #
 # After this, all attributes can be read in an OOP way, for example:
 #   r.questions # All questions, including the next (unanswered) one
-#   # => [#<Question:0x007faadb3459a8 @key="EL02">,
+#   # => [#<Question:0x007faadb3459a8 @key="EL02", @answer_value: 1>,
 #         #<Question:0x007faadb2d49d8 @key="EL03">]
 class Response < BaseModel
   attr_accessor :answer_values

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -2,7 +2,7 @@ class Response
   include ActiveModel::Model
   include ActiveModel::Serialization
   include ActiveModel::Validations
-  attr_accessor :answers, :old_estimate, :old_variance
+  attr_accessor :answers
 
   validates_with ResponseValidator
 
@@ -10,7 +10,7 @@ class Response
   %i( next_question_key estimate variance ).each do |r_attribute|
     define_method r_attribute do
       if valid?
-        RPackage.data_for(answers, old_estimate, old_variance)[r_attribute]
+        RPackage.data_for(answers)[r_attribute]
       else
         raise "Response must be valid when accessing `#{r_attribute}`.\n" \
               "Errors: #{errors.full_messages}"
@@ -25,5 +25,17 @@ class Response
 
   def next_question
     Question.find_by_key next_question_key
+  end
+
+  def without_answers_after(answer_key)
+    remaining_answers = answers.each_with_object(result: [], found: false) do |(key, value), memo|
+      unless memo[:found]
+        memo[:result] << [key, value]
+        memo[:found] = true if key == answer_key
+      end
+      memo
+    end[:result].to_h
+
+    self.class.new(answers: remaining_answers)
   end
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -1,41 +1,57 @@
-class Response
-  include ActiveModel::Model
-  include ActiveModel::Serialization
-  include ActiveModel::Validations
-  attr_accessor :answers
+# A stateless response to a given set of questions.
+# Initializing is done by setting answer_values as a hash, for example:
+#   r = Response.new(answer_values: { 'EL02' => 1 })
+#
+# After this, all attributes can be read in an OOP way, for example:
+#   r.questions # All questions, including the next (unanswered) one
+#   # => [#<Question:0x007faadb3459a8 @key="EL02">,
+#         #<Question:0x007faadb2d49d8 @key="EL03">]
+class Response < BaseModel
+  attr_accessor :answer_values
 
   validates_with ResponseValidator
 
   # accessors for attributes defined by R package
   %i( next_question_key estimate variance ).each do |r_attribute|
     define_method r_attribute do
-      if valid?
-        RPackage.data_for(answers)[r_attribute]
-      else
-        raise "Response must be valid when accessing `#{r_attribute}`.\n" \
-              "Errors: #{errors.full_messages}"
+      ensure_valid do
+        RPackage.data_for(answer_values)[r_attribute]
       end
     end
   end
 
   def initialize(attributes = {})
     super
-    self.answers ||= {}
+    self.answer_values ||= {}
+  end
+
+  def questions
+    completed_questions.push(next_question)
+  end
+
+  def completed_questions
+    answers.map(&:question)
+  end
+
+  def answers
+    answer_values.map do |key, value|
+      Answer.new key: key, value: value
+    end
   end
 
   def next_question
-    Question.find_by_key next_question_key
+    Question.new key: next_question_key
   end
 
   def without_answers_after(answer_key)
-    remaining_answers = answers.each_with_object(result: [], found: false) do |(key, value), memo|
+    remaining_answer_values = answer_values.each_with_object(result: [], found: false) do |(key, value), memo|
       unless memo[:found]
         memo[:result] << [key, value]
-        memo[:found] = true if key == answer_key
+        memo[:found] = key == answer_key
       end
       memo
     end[:result].to_h
 
-    self.class.new(answers: remaining_answers)
+    self.class.new(answer_values: remaining_answer_values)
   end
 end

--- a/app/models/response_validator.rb
+++ b/app/models/response_validator.rb
@@ -2,28 +2,10 @@ class ResponseValidator < ActiveModel::Validator
   def validate(response)
     @response = response # to prevent parameter duplication
 
-    validate_old_estimate
-    validate_old_variance
     validate_answers_integers
   end
 
   private
-
-  def validate_old_estimate
-    return if @response.old_estimate.nil?
-    valid_range = -20.0..20.0
-    unless in_float_range?(@response.old_estimate, valid_range)
-      @response.errors.add :old_estimate, invalid_float_message(@response.old_estimate, valid_range)
-    end
-  end
-
-  def validate_old_variance
-    return if @response.old_variance.nil?
-    valid_range = 0.0..25.0
-    unless in_float_range?(@response.old_variance, valid_range)
-      @response.errors.add :old_variance, invalid_float_message(@response.old_variance, valid_range)
-    end
-  end
 
   def invalid_float_message(given_value, valid_range)
     "must be a float between #{valid_range}, #{given_value} given"

--- a/app/models/response_validator.rb
+++ b/app/models/response_validator.rb
@@ -11,9 +11,7 @@ class ResponseValidator < ActiveModel::Validator
 
   def validate_answer_values_integers
     answers_with_non_integer_values = @response.answer_values.reject do |_key, value|
-      # rubocop:disable Style/RescueModifier
-      Integer(value) rescue false
-      # rubocop:enable Style/RescueModifier
+      value.is_a? Integer
     end
 
     if answers_with_non_integer_values.present?

--- a/app/serializers/response_serializer.rb
+++ b/app/serializers/response_serializer.rb
@@ -1,25 +1,17 @@
 class ResponseSerializer < ActiveModel::Serializer
-  attributes :initial_estimate, :initial_variance, :questions
+  attributes :estimate, :variance
 
-  def initial_estimate
-    Response.new.estimate
-  end
+  has_many :questions
+end
 
-  def initial_variance
-    Response.new.variance
-  end
+class QuestionSerializer < ActiveModel::Serializer
+  attributes :key, :text, :answer_value
 
-  def questions
-    object.answers.map do |key, value|
-      response_so_far = object.without_answers_after(key)
+  has_one :answer_option_set
+end
 
-      Question.find_by_key(key).as_json.merge(
-        answer: {
-          value: value,
-          new_estimate: response_so_far.estimate,
-          new_variance: response_so_far.variance
-        }
-      )
-    end.push object.next_question
-  end
+class AnswerOptionSetSerializer < ActiveModel::Serializer
+  attributes :id
+
+  has_many :answer_options
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,8 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
+  config.cache_store = :memory_store, { size: 64.megabytes }
+
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   mount Rack::HaproxyStatus::Endpoint.new(path: Rails.root.join('config/balancer_state')) => '/load_balancer_status'
   root to: 'app#index'
 
-  resources :responses, defaults: { format: :json }
+  resources :responses, defaults: { format: 'json' }, constraints: { format: 'json' }
 end

--- a/spec/controllers/responses_controller_spec.rb
+++ b/spec/controllers/responses_controller_spec.rb
@@ -10,7 +10,7 @@ describe ResponsesController, vcr: { cassette_name: 'screensmart', allow_playbac
 
     context 'with answers' do
       it 'includes the next question' do
-        post 'create', answers: { 'EL02' => 1 }
+        post 'create', answer_values: { 'EL02' => 1 }
         expect(assigns(:response).next_question.key).to eq 'EL03'
       end
     end

--- a/spec/controllers/responses_controller_spec.rb
+++ b/spec/controllers/responses_controller_spec.rb
@@ -10,11 +10,9 @@ describe ResponsesController, vcr: { cassette_name: 'screensmart', allow_playbac
 
     context 'with answers' do
       it 'includes the next question' do
-        post 'create', answer_values: { 'EL02' => 1 }
+        post 'create', { answer_values: { 'EL02' => 1 }, format: 'json' }, 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'
         expect(assigns(:response).next_question.key).to eq 'EL03'
       end
     end
-
-    it 'authorizes'
   end
 end

--- a/spec/controllers/responses_controller_spec.rb
+++ b/spec/controllers/responses_controller_spec.rb
@@ -10,7 +10,7 @@ describe ResponsesController, vcr: { cassette_name: 'screensmart', allow_playbac
 
     context 'with answers' do
       it 'includes the next question' do
-        post 'create', answers: { 'EL02' => 1 }, old_estimate: 1.0, old_variance: 0.5
+        post 'create', answers: { 'EL02' => 1 }
         expect(assigns(:response).next_question.key).to eq 'EL03'
       end
     end

--- a/spec/models/answer_option_set_spec.rb
+++ b/spec/models/answer_option_set_spec.rb
@@ -1,5 +1,5 @@
 describe AnswerOptionSet, vcr: { cassette_name: 'screensmart', allow_playback_repeats: true } do
-  let(:answer_option_set) { Question.all.first.answer_option_set }
+  let(:answer_option_set) { Question.new(key: 'EL02').answer_option_set }
   describe 'as an enumerable' do
     it 'iterates through the answer options' do
       expect(answer_option_set.first.text).to eq 'Oneens'

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,35 +1,19 @@
 describe Question, vcr: { cassette_name: 'screensmart', allow_playback_repeats: true } do
-  let(:questions) { described_class.all }
-  let(:question) { questions.first }
+  subject { described_class.new }
 
-  describe '.all' do
-    it 'returns parsed questions for all domains' do
-      expect(question).to be_a Question
-      expect(question.key).to eq 'EL02'
-      expect(question.text).to eq 'De tijd lijkt onnatuurlijk veel sneller of langzamer te gaan dan anders.'
+  describe '#text' do
+    it 'returns the question text when an existant key is given' do
+      subject.key = 'EL02'
+      expect(subject.text).to eq 'De tijd lijkt onnatuurlijk veel sneller of langzamer te gaan dan anders.'
     end
 
-    it 'parses the answer\'s option set' do
-      answer_option_set = question.answer_option_set
-      expect(answer_option_set).to be_a AnswerOptionSet
-      expect(answer_option_set.id).to eq 2
+    it 'raises an exception when a nonexistant key is given' do
+      subject.key = 'invalid_key'
+      expect { subject.text }.to raise_error Exception
     end
 
-    it 'parses the options in the answer option set' do
-      answer_option = question.answer_option_set.first
-      expect(answer_option).to be_a AnswerOption
-      expect(answer_option.value).to eq 0
-      expect(answer_option.text).to eq 'Oneens'
-    end
-  end
-
-  describe '.find_by_key' do
-    it 'finds a question by key' do
-      expect(described_class.find_by_key('EL02')).to be_a Question
-    end
-
-    it 'raises an exception when the key is not found' do
-      expect { described_class.find_by_key('bananentaart') }.to raise_exception 'question `bananentaart` not found'
+    it 'raises an exception when no key is given' do
+      expect { subject.text }.to raise_error Exception
     end
   end
 end

--- a/spec/models/r_package_spec.rb
+++ b/spec/models/r_package_spec.rb
@@ -2,6 +2,12 @@ describe RPackage, vcr: { cassette_name: 'screensmart', allow_playback_repeats: 
                           match_requests_on: [:body, :uri, :method] } do
   let(:described_module) { RPackage }
 
+  describe '.question_keys' do
+    it 'returns the question_keys' do
+      expect(described_module.question_keys).to eq %w( EL02 EL03 )
+    end
+  end
+
   describe '.questions' do
     before do
       enable_caching

--- a/spec/models/r_package_spec.rb
+++ b/spec/models/r_package_spec.rb
@@ -35,7 +35,7 @@ describe RPackage, vcr: { cassette_name: 'screensmart', allow_playback_repeats: 
 
     context 'with answers' do
       it 'returns a new next_question estimate and variance' do
-        expect(described_module.data_for('EL02' => '1')).to eq \
+        expect(described_module.data_for('EL02' => 1)).to eq \
           next_question_key: 'EL03',
           estimate: 0.7,
           variance: 0.6
@@ -74,18 +74,6 @@ describe RPackage, vcr: { cassette_name: 'screensmart', allow_playback_repeats: 
           second_call
         end
       end
-    end
-  end
-
-  describe '.integerize_values' do
-    it 'converts answer keys to integers' do
-      raw_answers = {
-        'EL02' => '1',
-        'EL03' => '0'
-      }
-      expect(described_module.integerize_values(raw_answers)).to eq \
-        'EL02' => 1,
-        'EL03' => 0
     end
   end
 end

--- a/spec/models/r_package_spec.rb
+++ b/spec/models/r_package_spec.rb
@@ -29,7 +29,7 @@ describe RPackage, vcr: { cassette_name: 'screensmart', allow_playback_repeats: 
 
     context 'with answers' do
       it 'returns a new next_question estimate and variance' do
-        expect(described_module.data_for({ 'EL02' => '1' }, 1.0, 0.5)).to eq \
+        expect(described_module.data_for('EL02' => '1')).to eq \
           next_question_key: 'EL03',
           estimate: 0.7,
           variance: 0.6
@@ -42,7 +42,7 @@ describe RPackage, vcr: { cassette_name: 'screensmart', allow_playback_repeats: 
       end
 
       def second_call
-        described_module.data_for({ 'EL02' => 1 }, 1.0, 0.5)
+        described_module.data_for('EL02' => 1)
       end
 
       before(:each) do
@@ -71,24 +71,15 @@ describe RPackage, vcr: { cassette_name: 'screensmart', allow_playback_repeats: 
     end
   end
 
-  describe '.answers_for_r' do
-    context 'with answers' do
-      it 'converts answer keys to integers' do
-        raw_answers = {
-          'EL02' => '1',
-          'EL03' => '0'
-        }
-        expect(described_module.answers_for_r(raw_answers)).to eq [
-          'EL02' => 1,
-          'EL03' => 0
-        ]
-      end
-    end
-
-    context 'with no answers' do
-      it 'returns an empty array' do
-        expect(described_module.answers_for_r({})).to eq []
-      end
+  describe '.integerize_values' do
+    it 'converts answer keys to integers' do
+      raw_answers = {
+        'EL02' => '1',
+        'EL03' => '0'
+      }
+      expect(described_module.integerize_values(raw_answers)).to eq \
+        'EL02' => 1,
+        'EL03' => 0
     end
   end
 end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -11,39 +11,12 @@ describe Response, vcr: { cassette_name: 'screensmart', allow_playback_repeats: 
     end
   end
 
-  describe 'validations' do
-    describe 'old_estimate' do
-      it 'is optional' do
-        expect(r).to have(0).errors_on :old_estimate
-      end
+  describe '#without_answers_after' do
+    it 'returns a new response without answers after the given key' do
+      initial_answers  = { 'EL02' => 1, 'EL40' => 1, 'EL03' => 0 }
+      expected_answers = { 'EL02' => 1, 'EL40' => 1 }
 
-      it 'must be a float' do
-        expect(r(old_estimate: 'a')).to have(1).errors_on :old_estimate
-      end
-
-      it 'must be between -20.0 and 20.0' do
-        expect(r(old_estimate: -20.1)).to have(1).errors_on :old_estimate
-      end
-    end
-
-    describe 'old_variance' do
-      it 'is optional' do
-        expect(r).to have(0).errors_on :old_variance
-      end
-
-      it 'must be a float' do
-        expect(r(old_variance: 'a')).to have(1).errors_on :old_variance
-      end
-
-      it 'must be between 0 and 1.0' do
-        expect(r(old_variance: 1.1)).to have(1).errors_on :old_variance
-      end
-    end
-
-    describe 'answers' do
-      it 'must have all integer values' do
-        expect(r(answers: { 'EL02' => '1.0' })).to have(1).errors_on :answers
-      end
+      expect(r(answers: initial_answers).without_answers_after('EL40').answers).to eq expected_answers
     end
   end
 end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -6,7 +6,7 @@ describe Response, vcr: { cassette_name: 'screensmart', allow_playback_repeats: 
   end
 
   describe '#next_question' do
-    it 'returns the next question from opencpu' do
+    it 'returns the next question from the R package' do
       expect(response.next_question.key).to eq 'EL02'
     end
   end
@@ -16,7 +16,18 @@ describe Response, vcr: { cassette_name: 'screensmart', allow_playback_repeats: 
       initial_answers  = { 'EL02' => 1, 'EL40' => 1, 'EL03' => 0 }
       expected_answers = { 'EL02' => 1, 'EL40' => 1 }
 
-      expect(r(answers: initial_answers).without_answers_after('EL40').answers).to eq expected_answers
+      expect(r(answer_values: initial_answers).without_answers_after('EL40').answer_values).to eq expected_answers
     end
+  end
+
+  describe '#questions' do
+    it 'contains all answered questions plus the next one' do
+      response = r(answer_values: { 'EL02' => 1 })
+      expect(response.questions.map(&:key)).to eq %w( EL02 EL03 )
+    end
+  end
+
+  describe '#answers' do
+    it 'contains all answers to filled out questions'
   end
 end

--- a/spec/models/response_validator_spec.rb
+++ b/spec/models/response_validator_spec.rb
@@ -1,0 +1,34 @@
+describe ResponseValidator, vcr: { cassette_name: 'screensmart', allow_playback_repeats: true } do
+  let(:subject) { Response.new }
+
+  describe '#validate' do
+    def expect_error
+      expect(subject).not_to be_valid
+      expect(subject).to have(1).errors_on :answer_values
+    end
+
+    def expect_no_error
+      expect(subject).to be_valid
+      expect(subject).to have(0).errors_on :answer_values
+    end
+
+    it 'validates answer values are integers' do
+      subject.answer_values = { 'EL02' => 'not an integer' }
+      expect_error
+    end
+
+    it 'validates answer keys exist' do
+      allow(RPackage).to receive(:question_keys).and_return %w( EL02 EL03 )
+
+      subject.answer_values = { 'nonexistant_key' => 1 }
+      expect_error
+    end
+
+    it 'is valid with proper keys and values' do
+      expect_no_error
+
+      subject.answer_values = { 'EL02' => 1 }
+      expect_no_error
+    end
+  end
+end

--- a/spec/serializers/response_serializer_spec.rb
+++ b/spec/serializers/response_serializer_spec.rb
@@ -1,37 +1,25 @@
 describe ResponseSerializer, vcr: { cassette_name: 'screensmart', allow_playback_repeats: true,
                                     match_requests_on: [:body, :uri, :method] } do
   subject do
-    response = Response.new(answers: { 'EL02' => 1 })
+    response = Response.new(answer_values: { 'EL02' => 1 })
     JSON.parse(ResponseSerializer.new(response).to_json)['response']
   end
 
-  it 'includes id and next_question' do
-    expect(subject).to eq({
-      initial_estimate: 1.0,
-      initial_variance: 0.5,
+  def pretty(json)
+    JSON.pretty_generate(json)
+  end
+
+  it 'includes estimate, variance and questions' do
+    expect(pretty(subject)).to eq(pretty({
+      estimate: 0.7,
+      variance: 0.6,
       questions: [{
-          key: 'EL02',
-          text: 'De tijd lijkt onnatuurlijk veel sneller of langzamer te gaan dan anders.',
-          answer_option_set: [
-            {
-              value: 0,
-              text: 'Oneens'
-            },
-            {
-              value: 1,
-              text: 'Eens'
-            }
-          ],
-          answer: {
-            value: 1,
-            new_estimate: 0.7,
-            new_variance: 0.6
-          }
-        },
-        {
-          key: 'EL03',
-          text: 'Vraag 3',
-          answer_option_set: [
+        key: 'EL02',
+        text: 'De tijd lijkt onnatuurlijk veel sneller of langzamer te gaan dan anders.',
+        answer_value: 1,
+        answer_option_set: {
+          id: 2,
+          answer_options: [
             {
               value: 0,
               text: 'Oneens'
@@ -42,7 +30,25 @@ describe ResponseSerializer, vcr: { cassette_name: 'screensmart', allow_playback
             }
           ]
         }
+      }, {
+        key: 'EL03',
+        text: 'Vraag 3',
+        answer_value: nil,
+        answer_option_set: {
+          id: 2,
+          answer_options: [
+            {
+              value: 0,
+              text: 'Oneens'
+            },
+            {
+              value: 1,
+              text: 'Eens'
+            }
+          ]
+        }
+      }
       ]
-    }.with_indifferent_access)
+    }.with_indifferent_access))
   end
 end

--- a/spec/serializers/response_serializer_spec.rb
+++ b/spec/serializers/response_serializer_spec.rb
@@ -9,8 +9,7 @@ describe ResponseSerializer, vcr: { cassette_name: 'screensmart', allow_playback
     expect(subject).to eq({
       initial_estimate: 1.0,
       initial_variance: 0.5,
-      questions: [
-        {
+      questions: [{
           key: 'EL02',
           text: 'De tijd lijkt onnatuurlijk veel sneller of langzamer te gaan dan anders.',
           answer_option_set: [

--- a/spec/serializers/response_serializer_spec.rb
+++ b/spec/serializers/response_serializer_spec.rb
@@ -1,14 +1,14 @@
 describe ResponseSerializer, vcr: { cassette_name: 'screensmart', allow_playback_repeats: true,
                                     match_requests_on: [:body, :uri, :method] } do
   subject do
-    response = Response.new(answers: { 'EL02' => 1 }, old_estimate: 1.0, old_variance: 0.5)
+    response = Response.new(answers: { 'EL02' => 1 })
     JSON.parse(ResponseSerializer.new(response).to_json)['response']
   end
 
   it 'includes id and next_question' do
     expect(subject).to eq({
-      estimate: 0.7,
-      variance: 0.6,
+      initial_estimate: 1.0,
+      initial_variance: 0.5,
       questions: [
         {
           key: 'EL02',
@@ -23,7 +23,11 @@ describe ResponseSerializer, vcr: { cassette_name: 'screensmart', allow_playback
               text: 'Eens'
             }
           ],
-          answer: 1
+          answer: {
+            value: 1,
+            new_estimate: 0.7,
+            new_variance: 0.6
+          }
         },
         {
           key: 'EL03',


### PR DESCRIPTION
In the old model, when you changed an old answer it would make the outcome incorrect because the *current* estimate/variance was used, rather than the estimate/variance at the time of originally filling out the question