### PR TITLE
Event maken als een invulling voltooid wordt, invulling hierna sluiten

### DIFF
--- a/app/assets/javascripts/actions/index.coffee
+++ b/app/assets/javascripts/actions/index.coffee
@@ -68,7 +68,12 @@ Screensmart.Actions =
       dispatch @startFinishResponse()
       $.putJSON("/responses/#{responseUUID}").then (data) =>
         dispatch @receiveFinishResponse(data)
-        dispatch routerActions.push('/') #  Return to home page
+        dispatch
+          type: '@@router/LOCATION_CHANGE'
+          payload:
+            pathname: '/'
+            search: ''
+            hash: ''
 
   startFinishResponse: ->
     type: 'START_FINISH_RESPONSE'

--- a/app/assets/javascripts/actions/index.coffee
+++ b/app/assets/javascripts/actions/index.coffee
@@ -35,8 +35,14 @@ Screensmart.Actions =
   createResponse: (invitationUUID) ->
     (dispatch) =>
       dispatch @startResponseUpdate()
-      $.postJSON("/responses", {invitationUUID}).then (data) =>
+      $.postJSON("/responses", {invitationUUID})
+      .then (data) =>
         dispatch @receiveResponseUpdate(data)
+      .fail (response) =>
+        if response.status == 423 # 423 Locked
+          dispatch @addMessage 'U heeft de vragenlijst al ingevuld'
+        else
+          throw new Error 'Unknown error'
 
   postAnswer: (questionId, answerValue) ->
     (dispatch, getState) =>

--- a/app/assets/javascripts/actions/index.coffee
+++ b/app/assets/javascripts/actions/index.coffee
@@ -1,4 +1,4 @@
-{ routerActions } = ReactRouterRedux
+{ push } = ReactRouterRedux
 
 Screensmart.Actions =
   fetchDomains: ->
@@ -68,12 +68,7 @@ Screensmart.Actions =
       dispatch @startFinishResponse()
       $.putJSON("/responses/#{responseUUID}").then (data) =>
         dispatch @receiveFinishResponse(data)
-        dispatch
-          type: '@@router/LOCATION_CHANGE'
-          payload:
-            pathname: '/'
-            search: ''
-            hash: ''
+        dispatch push('/')
 
   startFinishResponse: ->
     type: 'START_FINISH_RESPONSE'

--- a/app/assets/javascripts/actions/index.coffee
+++ b/app/assets/javascripts/actions/index.coffee
@@ -1,3 +1,5 @@
+{ routerActions } = ReactRouterRedux
+
 Screensmart.Actions =
   fetchDomains: ->
     (dispatch) =>
@@ -60,3 +62,17 @@ Screensmart.Actions =
   receiveResponseUpdate: (data) ->
     type: 'RECEIVE_RESPONSE_UPDATE'
     response: data.response
+
+  finishResponse: (responseUUID) ->
+    (dispatch) =>
+      dispatch @startFinishResponse()
+      $.putJSON("/responses/#{responseUUID}").then (data) =>
+        dispatch @receiveFinishResponse(data)
+        dispatch routerActions.push('/') #  Return to home page
+
+  startFinishResponse: ->
+    type: 'START_FINISH_RESPONSE'
+
+  receiveFinishResponse: (data) ->
+    type: 'RECEIVE_FINISH_RESPONSE'
+    response: data

--- a/app/assets/javascripts/actions/index.coffee
+++ b/app/assets/javascripts/actions/index.coffee
@@ -68,7 +68,6 @@ Screensmart.Actions =
       dispatch @startFinishResponse()
       $.putJSON("/responses/#{responseUUID}").then (data) =>
         dispatch @receiveFinishResponse(data)
-        dispatch push('/')
 
   startFinishResponse: ->
     type: 'START_FINISH_RESPONSE'

--- a/app/assets/javascripts/actions/index.coffee
+++ b/app/assets/javascripts/actions/index.coffee
@@ -1,5 +1,3 @@
-{ push } = ReactRouterRedux
-
 Screensmart.Actions =
   fetchDomains: ->
     (dispatch) =>

--- a/app/assets/javascripts/components/outcome.coffee
+++ b/app/assets/javascripts/components/outcome.coffee
@@ -1,4 +1,4 @@
-{div, i, p} = React.DOM
+{ div, i, p, a } = React.DOM
 
 @Outcome = React.createClass
   displayName: 'Outcome'
@@ -7,6 +7,10 @@
 
   propTypes: ->
     response: React.PropTypes.object.isRequired
+
+  onFinishClick: ->
+    { dispatch } = Screensmart.store
+    dispatch Screensmart.Actions.finishResponse(@props.response.uuid)
 
   render: ->
     {estimate, variance} = @props.response
@@ -19,3 +23,7 @@
       p
         clasName: ''
         "Estimate: #{estimate}, variance: #{variance}"
+      a
+        className: ''
+        onClick: @onFinishClick
+        'Klaar'

--- a/app/assets/javascripts/components/outcome.coffee
+++ b/app/assets/javascripts/components/outcome.coffee
@@ -1,4 +1,4 @@
-{ div, i, p, a } = React.DOM
+{ div, i, p, a, button, span } = React.DOM
 
 @Outcome = React.createClass
   displayName: 'Outcome'
@@ -13,17 +13,34 @@
     dispatch Screensmart.Actions.finishResponse(@props.response.uuid)
 
   render: ->
-    {estimate, variance} = @props.response
+    { estimate, variance, finished } = @props.response
 
     div
       className: 'outcome'
-      p
-        className: ''
-        'Bedankt voor het invullen.'
-      p
-        clasName: ''
-        "Estimate: #{estimate}, variance: #{variance}"
-      a
-        className: ''
-        onClick: @onFinishClick
-        'Klaar'
+      if finished
+        [
+          p
+            key: 'thanks'
+            [
+              i
+                className: 'fa fa-2x fa-check'
+                key: 'check'
+              span
+                key: 'thanks'
+                'Bedankt voor het invullen'
+            ]
+          p
+            key: 'estimate-variance'
+            "Estimate: #{estimate}, variance: #{variance}"
+        ]
+      else
+        [
+          p
+            key: 'instructions'
+            'U kunt de invulling afronden of uw antwoorden aanpassen'
+          button
+            type: 'submit'
+            key: 'button'
+            onClick: @onFinishClick
+            'Afronden'
+        ]

--- a/app/assets/javascripts/entry_point.coffee
+++ b/app/assets/javascripts/entry_point.coffee
@@ -1,12 +1,13 @@
 { createStore, compose, applyMiddleware, thunk, combineReducers } = Redux
 { Router, browserHistory } = ReactRouter
-{ syncHistoryWithStore } = ReactRouterRedux
+{ syncHistoryWithStore, routerMiddleware } = ReactRouterRedux
 { createFactory } = React
 
 document.addEventListener 'DOMContentLoaded', ->
   middlewares = compose applyMiddleware(thunk),
-                if window.devToolsExtension then window.devToolsExtension()
-                else (f) -> f
+                        applyMiddleware(routerMiddleware(browserHistory)),
+                        if window.devToolsExtension then window.devToolsExtension()
+                        else (f) -> f
 
   store = Screensmart.store = createStore Screensmart.reducers, middlewares
 

--- a/app/assets/javascripts/error_handler.coffee
+++ b/app/assets/javascripts/error_handler.coffee
@@ -25,7 +25,6 @@ prettyStoreContents = ->
 $(document).ajaxError (event, xhr, settings, error ) ->
   { method, url } = settings
   { status } = xhr
-  throw new Error "#{method} #{url} failed: #{status} #{error}"
 
   if window.environment == 'development'
     console.log

--- a/app/assets/javascripts/jquery_configuration.coffee
+++ b/app/assets/javascripts/jquery_configuration.coffee
@@ -24,3 +24,10 @@ $.postJSON = (url, data, args = {}) ->
     method: 'POST'
     data: JSON.stringify data
     args...
+
+$.putJSON = (url, data, args = {}) ->
+  $.ajax
+    url: url
+    method: 'PUT'
+    data: JSON.stringify data
+    args...

--- a/app/assets/javascripts/reducers/index.coffee
+++ b/app/assets/javascripts/reducers/index.coffee
@@ -66,13 +66,9 @@ Screensmart.reducers = Redux.combineReducers
         merge responseWithDoneTrue \
                 response
 
-      when 'START_FINISH_RESPONSE'
-        merge response,
-              loading: true
-
       when 'RECEIVE_FINISH_RESPONSE'
         merge response,
-              loading: false
+              finished: true
 
       else
         response

--- a/app/assets/javascripts/reducers/index.coffee
+++ b/app/assets/javascripts/reducers/index.coffee
@@ -62,6 +62,18 @@ Screensmart.reducers = Redux.combineReducers
               action.response,
               loading: false
 
+      when 'FINISH_RESPONSE'
+        merge responseWithDoneTrue \
+                response
+
+      when 'START_FINISH_RESPONSE'
+        merge response,
+              loading: true
+
+      when 'RECEIVE_FINISH_RESPONSE'
+        merge response,
+              loading: false
+
       else
         response
 
@@ -87,6 +99,10 @@ responseWithDoneFalse = (response) ->
         done: false # Ensure no old outcome is shown
                     # in case user changes an answer
                     # after finishing
+
+responseWithDoneTrue = (response) ->
+  merge response,
+        done: true
 
 responseWithoutNonFilledOutQuestions = (response) ->
   merge response,

--- a/app/assets/stylesheets/_globals.sass
+++ b/app/assets/stylesheets/_globals.sass
@@ -120,6 +120,20 @@ header
         &:last-of-type
           @extend .active-item
 
+button[type="submit"]
+  border-radius: 5px
+  padding: 5px 15px
+  font-size: 1.2rem
+  background-color: $form-submit-background-color
+  color: $form-submit-color
+  border: 2px solid $form-submit-border-color
+  margin-right: 1.2rem
+  margin-bottom: 10px
+  &:hover
+    background-color: $form-submit-background-color-hover
+    border: 2px solid $form-submit-border-color-hover
+    cursor: pointer
+
 .small
   font-size: 0.9rem
 

--- a/app/assets/stylesheets/invitations.sass
+++ b/app/assets/stylesheets/invitations.sass
@@ -26,19 +26,6 @@
       li
         input[type="radio"]
           margin-right: 1rem
-  button[type="submit"]
-    border-radius: 5px
-    padding: 5px 15px
-    font-size: 1.2rem
-    background-color: $form-submit-background-color
-    color: $form-submit-color
-    border: 2px solid $form-submit-border-color
-    margin-right: 1.2rem
-    margin-bottom: 10px
-    &:hover
-      background-color: $form-submit-background-color-hover
-      border: 2px solid $form-submit-border-color-hover
-      cursor: pointer
 
   .invalid
     border: 2px solid $screensmart-red

--- a/app/commands/accept_invitation.rb
+++ b/app/commands/accept_invitation.rb
@@ -1,4 +1,5 @@
 class AcceptInvitation < ActiveInteraction::Base
+  class AlreadyFinished < StandardError; end
   string :invitation_uuid
 
   validates :invitation_uuid, presence: true
@@ -12,5 +13,6 @@ class AcceptInvitation < ActiveInteraction::Base
   def validate_response_has_not_been_finished
     return unless Events::ResponseFinished.find_by(invitation_uuid: invitation_uuid)
     errors.add(:invitation_uuid, 'has already been finished')
+    raise AlreadyFinished
   end
 end

--- a/app/commands/accept_invitation.rb
+++ b/app/commands/accept_invitation.rb
@@ -2,9 +2,15 @@ class AcceptInvitation < ActiveInteraction::Base
   string :invitation_uuid
 
   validates :invitation_uuid, presence: true
+  validate :validate_response_has_not_been_finished
 
   def execute
     Events::InvitationAccepted.create! invitation_uuid: invitation_uuid,
                                        response_uuid: SecureRandom.uuid
+  end
+
+  def validate_response_has_not_been_finished
+    return unless Events::ResponseFinished.find_by(invitation_uuid: invitation_uuid)
+    errors.add(:invitation_uuid, 'has already been finished')
   end
 end

--- a/app/commands/finish_response.rb
+++ b/app/commands/finish_response.rb
@@ -31,7 +31,7 @@ class FinishResponse < ActiveInteraction::Base
   end
 
   def validate_all_questions_answered
-    return if response.done
+    return if !response_exists? || response.done
     errors.add(:response_uuid, 'not all questions have been answered')
   end
 
@@ -41,6 +41,10 @@ class FinishResponse < ActiveInteraction::Base
   end
 
   def response
-    Response.find(response_uuid)
+    Response.find response_uuid
+  end
+
+  def response_exists?
+    Response.exists? response_uuid
   end
 end

--- a/app/commands/finish_response.rb
+++ b/app/commands/finish_response.rb
@@ -5,7 +5,7 @@ class FinishResponse < ActiveInteraction::Base
   validate :validate_response_uuid_is_found
   validate :validate_invitation_uuid_is_found
   validate :validate_response_is_not_finished
-  validate :all_questions_answered
+  validate :validate_all_questions_answered
 
   def execute
     Events::ResponseFinished.create! invitation_uuid: invitation.invitation_uuid,
@@ -29,8 +29,8 @@ class FinishResponse < ActiveInteraction::Base
     errors.add(:response_uuid, 'has already been finished')
   end
 
-  def all_questions_answered
-    return unless serialized_response.done
+  def validate_all_questions_answered
+    return if serialized_response.done
     errors.add(:response_uuid, 'not all questions have been answered')
   end
 

--- a/app/commands/finish_response.rb
+++ b/app/commands/finish_response.rb
@@ -10,8 +10,9 @@ class FinishResponse < ActiveInteraction::Base
   def execute
     Events::ResponseFinished.create! invitation_uuid: invitation.invitation_uuid,
                                      response_uuid: response_uuid,
-                                     estimate: serialized_response.estimate,
-                                     variance: serialized_response.variance
+                                     answer_values: response.answer_values,
+                                     estimate: response.estimate,
+                                     variance: response.variance
   end
 
   def validate_response_uuid_is_found
@@ -30,7 +31,7 @@ class FinishResponse < ActiveInteraction::Base
   end
 
   def validate_all_questions_answered
-    return if serialized_response.done
+    return if response.done
     errors.add(:response_uuid, 'not all questions have been answered')
   end
 
@@ -39,11 +40,7 @@ class FinishResponse < ActiveInteraction::Base
     Events::InvitationAccepted.find_by(response_uuid: response_uuid)
   end
 
-  def serialized_response
-    if Response.exists?(response_uuid)
-      @serialized_response ||= ResponseSerializer.new(Response.find(response_uuid))
-    else
-      OpenStruct.new(done: false) # return this when response is not found
-    end
+  def response
+    Response.find(response_uuid)
   end
 end

--- a/app/commands/finish_response.rb
+++ b/app/commands/finish_response.rb
@@ -3,16 +3,31 @@ class FinishResponse < ActiveInteraction::Base
 
   validates :response_uuid, presence: true
   validate :validate_response_uuid_is_found
+  validate :validate_invitation_uuid_is_found
+  validate :validate_response_not_finished
 
   def execute
-    invitation_accepted = Events::InvitationAccepted.find_by(response_uuid: response_uuid)
-
-    Events::ResponseFinished.create! invitation_uuid: invitation_accepted.invitation_uuid,
+    Events::ResponseFinished.create! invitation_uuid: invitation.invitation_uuid,
                                      response_uuid: response_uuid
   end
 
   def validate_response_uuid_is_found
     return if Response.exists? response_uuid
     errors.add(:response_uuid, 'is unknown')
+  end
+
+  def validate_invitation_uuid_is_found
+    return if invitation
+    errors.add(:invitation_uuid, 'is not found')
+  end
+
+  def validate_response_not_finished
+    return unless Events::ResponseFinished.find_by(response_uuid: response_uuid)
+    errors.add(:response_uuid, 'has already been finished')
+  end
+
+  # The invitation that has been used to start the response
+  def invitation
+    Events::InvitationAccepted.find_by(response_uuid: response_uuid)
   end
 end

--- a/app/commands/finish_response.rb
+++ b/app/commands/finish_response.rb
@@ -4,11 +4,14 @@ class FinishResponse < ActiveInteraction::Base
   validates :response_uuid, presence: true
   validate :validate_response_uuid_is_found
   validate :validate_invitation_uuid_is_found
-  validate :validate_response_not_finished
+  validate :validate_response_is_not_finished
+  validate :all_questions_answered
 
   def execute
     Events::ResponseFinished.create! invitation_uuid: invitation.invitation_uuid,
-                                     response_uuid: response_uuid
+                                     response_uuid: response_uuid,
+                                     estimate: serialized_response.estimate,
+                                     variance: serialized_response.variance
   end
 
   def validate_response_uuid_is_found
@@ -21,13 +24,26 @@ class FinishResponse < ActiveInteraction::Base
     errors.add(:invitation_uuid, 'is not found')
   end
 
-  def validate_response_not_finished
+  def validate_response_is_not_finished
     return unless Events::ResponseFinished.find_by(response_uuid: response_uuid)
     errors.add(:response_uuid, 'has already been finished')
+  end
+
+  def all_questions_answered
+    return unless serialized_response.done
+    errors.add(:response_uuid, 'not all questions have been answered')
   end
 
   # The invitation that has been used to start the response
   def invitation
     Events::InvitationAccepted.find_by(response_uuid: response_uuid)
+  end
+
+  def serialized_response
+    if Response.exists?(response_uuid)
+      @serialized_response ||= ResponseSerializer.new(Response.find(response_uuid))
+    else
+      OpenStruct.new(done: false) # return this when response is not found
+    end
   end
 end

--- a/app/commands/finish_response.rb
+++ b/app/commands/finish_response.rb
@@ -1,0 +1,18 @@
+class FinishResponse < ActiveInteraction::Base
+  string :response_uuid
+
+  validates :response_uuid, presence: true
+  validate :validate_response_uuid_is_found
+
+  def execute
+    invitation_accepted = Events::InvitationAccepted.find_by(response_uuid: response_uuid)
+
+    Events::ResponseFinished.create! invitation_uuid: invitation_accepted.invitation_uuid,
+                                     response_uuid: response_uuid
+  end
+
+  def validate_response_uuid_is_found
+    return if Response.exists? response_uuid
+    errors.add(:response_uuid, 'is unknown')
+  end
+end

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -8,4 +8,13 @@ class ResponsesController < ApplicationController
     response = Response.find params[:id]
     render json: ResponseSerializer.new(response).as_json
   end
+
+  def update
+    response_finished = FinishResponse.run! response_uuid: params[:id]
+    if response_finished.valid?
+      render json: { result: 'ok', message: 'Thanks!' }
+    else
+      render json: { result: 'error', errors: response_finished.errors.messages }
+    end
+  end
 end

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -12,9 +12,9 @@ class ResponsesController < ApplicationController
   def update
     response_finished = FinishResponse.run response_uuid: params[:id]
     if response_finished.valid?
-      render json: { result: 'ok', message: 'Thanks!' }
+      head :ok
     else
-      render json: { result: 'error', errors: response_finished.errors.messages }
+      head :unprocessable_entity
     end
   end
 end

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -10,7 +10,7 @@ class ResponsesController < ApplicationController
   end
 
   def update
-    response_finished = FinishResponse.run! response_uuid: params[:id]
+    response_finished = FinishResponse.run response_uuid: params[:id]
     if response_finished.valid?
       render json: { result: 'ok', message: 'Thanks!' }
     else

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -1,4 +1,6 @@
 class ResponsesController < ApplicationController
+  rescue_from AcceptInvitation::AlreadyFinished, with: :already_finished
+
   def create
     invitation_accepted = AcceptInvitation.run! params.slice(:invitation_uuid)
     redirect_to response_url id: invitation_accepted.response_uuid
@@ -16,5 +18,11 @@ class ResponsesController < ApplicationController
     else
       head :unprocessable_entity
     end
+  end
+
+  private
+
+  def already_finished
+    head :locked
   end
 end

--- a/app/models/events/event.rb
+++ b/app/models/events/event.rb
@@ -2,10 +2,10 @@ module Events
   class Event < ActiveRecord::Base
     validates :type, presence: true
 
-    def self.event_attributes(attributes)
-      jsonb_accessor :data, attributes
+    def self.event_attributes(untyped_attributes = nil, typed_attributes)
+      jsonb_accessor :data, untyped_attributes, typed_attributes
 
-      attributes.each do |attribute, _|
+      typed_attributes.each do |attribute, _|
         define_singleton_method "find_by_#{attribute}" do |value|
           records = send("with_#{attribute}", value)
           raise "Expected to find one #{self}, got #{records.count}" unless records.count == 1

--- a/app/models/events/response_finished.rb
+++ b/app/models/events/response_finished.rb
@@ -1,5 +1,6 @@
 module Events
   class ResponseFinished < Event
-    # No event attributes, invitation_uuid + response_uuid columns are enough
+    event_attributes estimate: :float,
+                     variance: :float
   end
 end

--- a/app/models/events/response_finished.rb
+++ b/app/models/events/response_finished.rb
@@ -1,6 +1,7 @@
 module Events
   class ResponseFinished < Event
-    event_attributes estimate: :float,
+    event_attributes :answer_values,
+                     estimate: :float,
                      variance: :float
   end
 end

--- a/app/models/events/response_finished.rb
+++ b/app/models/events/response_finished.rb
@@ -1,0 +1,5 @@
+module Events
+  class ResponseFinished < Event
+    # No event attributes, invitation_uuid + response_uuid columns are enough
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to: 'app#index'
 
   scope defaults: { format: 'json' }, constraints: { format: 'json' } do
-    resources :responses, only: [:create, :show]
+    resources :responses, only: [:create, :show, :update]
     # get 'responses', controller: 'responses', action: 'show', as: 'response'
     resources :answers, only: [:create]
     resources :domains, only: [:index]

--- a/spec/cassettes/screensmart.yml
+++ b/spec/cassettes/screensmart.yml
@@ -329,7 +329,7 @@ http_interactions:
           "estimate": [0.7],
           "variance": [0.6],
           "answers": [],
-          "continue_test": true
+          "continue_test": false
         }
     http_version: 
   recorded_at: Thu, 03 Mar 2016 09:29:33 GMT

--- a/spec/commands/accept_invitation_spec.rb
+++ b/spec/commands/accept_invitation_spec.rb
@@ -1,13 +1,13 @@
 describe AcceptInvitation do
   subject { described_class.run(params) }
 
-  context 'with valid parameters' do
-    let(:invitation_sent) do
-      SendInvitation.run! respondent_email: 'some@respondent.dev',
-                          requester_email: 'some@doctor.dev',
-                          domain_ids: ['POS-PQ']
-    end
+  let(:invitation_sent) do
+    SendInvitation.run! respondent_email: 'some@respondent.dev',
+                        requester_email: 'some@doctor.dev',
+                        domain_ids: ['POS-PQ']
+  end
 
+  context 'with valid parameters' do
     let(:params) { { invitation_uuid: invitation_sent.invitation_uuid } }
     it 'creates an InvitationAccepted event' do
       expect { subject }.to change { Events::InvitationAccepted.count }.by(1)
@@ -16,6 +16,19 @@ describe AcceptInvitation do
 
   context 'invitation_uuid is missing' do
     let(:params) { { invitation_uuid: '' } }
+    it { is_expected.to have(1).errors_on :invitation_uuid }
+  end
+
+  context 'response has already been finished' do
+    let(:params) { { invitation_uuid: invitation_sent.invitation_uuid } }
+
+    before do
+      Events::ResponseFinished.create!(
+        invitation_uuid: invitation_sent.invitation_uuid,
+        response_uuid: SecureRandom.uuid
+      )
+    end
+
     it { is_expected.to have(1).errors_on :invitation_uuid }
   end
 end

--- a/spec/commands/accept_invitation_spec.rb
+++ b/spec/commands/accept_invitation_spec.rb
@@ -29,6 +29,8 @@ describe AcceptInvitation do
       )
     end
 
-    it { is_expected.to have(1).errors_on :invitation_uuid }
+    it 'raises an exception' do
+      expect { subject }.to raise_error AcceptInvitation::AlreadyFinished
+    end
   end
 end

--- a/spec/commands/finish_response_spec.rb
+++ b/spec/commands/finish_response_spec.rb
@@ -23,6 +23,14 @@ describe FinishResponse do
     it 'creates an ReponseFinished event ' do
       expect { subject }.to change { Events::ResponseFinished.count }.by(1)
     end
+
+    it 'saves the estimate and variance' do
+      Events::AnswerSet.create! response_uuid: response_uuid,
+                                question_id: 'EL02',
+                                answer_value: 1
+      expect(subject.result.estimate).to be_a(Float)
+      expect(subject.result.variance).to be_a(Float)
+    end
   end
 
   context 'with invalid parameters' do

--- a/spec/commands/finish_response_spec.rb
+++ b/spec/commands/finish_response_spec.rb
@@ -3,14 +3,14 @@ describe FinishResponse do
   let!(:response_uuid) { SecureRandom.uuid }
 
   before do
-    invitation_sent = Events::InvitationSent.create!(
+    Events::InvitationSent.create!(
       invitation_uuid: invitation_uuid,
       requester_email: 'requester@example.dev',
       domain_ids: ['POS-PQ']
     )
 
     Events::InvitationAccepted.create!(
-      invitation_uuid: invitation_sent.invitation_uuid,
+      invitation_uuid: invitation_uuid,
       response_uuid: response_uuid
     )
   end
@@ -38,6 +38,21 @@ describe FinishResponse do
         params[:response_uuid] = 'FOOBAR'
         expect(subject).to have(1).errors_on(:response_uuid)
       end
+    end
+  end
+
+  context 'when response is already finished' do
+    let(:params) { { response_uuid: response_uuid } }
+
+    before do
+      Events::ResponseFinished.create!(
+        invitation_uuid: invitation_uuid,
+        response_uuid: response_uuid
+      )
+    end
+
+    it 'does not create another ResponseFinished event' do
+      expect(subject).to have(1).errors_on(:response_uuid)
     end
   end
 end

--- a/spec/commands/finish_response_spec.rb
+++ b/spec/commands/finish_response_spec.rb
@@ -1,0 +1,43 @@
+describe FinishResponse do
+  let!(:invitation_uuid) { SecureRandom.uuid }
+  let!(:response_uuid) { SecureRandom.uuid }
+
+  before do
+    invitation_sent = Events::InvitationSent.create!(
+      invitation_uuid: invitation_uuid,
+      requester_email: 'requester@example.dev',
+      domain_ids: ['POS-PQ']
+    )
+
+    Events::InvitationAccepted.create!(
+      invitation_uuid: invitation_sent.invitation_uuid,
+      response_uuid: response_uuid
+    )
+  end
+
+  subject { described_class.run(params) }
+
+  context 'with valid parameters' do
+    let(:params) { { response_uuid: response_uuid } }
+
+    it 'creates an ReponseFinished event ' do
+      expect { subject }.to change { Events::ResponseFinished.count }.by(1)
+    end
+  end
+
+  context 'with invalid parameters' do
+    let(:params) { { response_uuid: response_uuid } }
+
+    context 'response_uuid is invalid' do
+      it 'has an error when uuid is missing' do
+        params[:response_uuid] = ''
+        expect(subject).to have(2).errors_on(:response_uuid)
+      end
+
+      it 'has an error when uuid is unkown' do
+        params[:response_uuid] = 'FOOBAR'
+        expect(subject).to have(1).errors_on(:response_uuid)
+      end
+    end
+  end
+end

--- a/spec/commands/set_answer_spec.rb
+++ b/spec/commands/set_answer_spec.rb
@@ -57,4 +57,11 @@ describe SetAnswer do
       end
     end
   end
+
+  context 'when response has been finished' do
+    it 'has an error when trying to set an answer' do
+      Events::ResponseFinished.create!(response_uuid: response_uuid)
+      expect(subject).to have(1).errors_on(:response_uuid)
+    end
+  end
 end

--- a/spec/controllers/responses_controller_spec.rb
+++ b/spec/controllers/responses_controller_spec.rb
@@ -32,6 +32,14 @@ describe ResponsesController do
       AcceptInvitation.run! invitation_uuid: invitation_sent.invitation_uuid
     end
 
+    before do
+      Events::AnswerSet.create!(
+        response_uuid: invitation_accepted.response_uuid,
+        question_id: 'enough_answers_to_be_done',
+        answer_value: 1
+      )
+    end
+
     subject { put :update, id: invitation_accepted.response_uuid }
 
     it 'finishes the response' do

--- a/spec/controllers/responses_controller_spec.rb
+++ b/spec/controllers/responses_controller_spec.rb
@@ -26,4 +26,16 @@ describe ResponsesController do
       expect(response.body).to eq ResponseSerializer.new(model).as_json.to_json
     end
   end
+
+  describe '#update' do
+    let!(:invitation_accepted) do
+      AcceptInvitation.run! invitation_uuid: invitation_sent.invitation_uuid
+    end
+
+    subject { put :update, id: invitation_accepted.response_uuid }
+
+    it 'finishes the response' do
+      expect { subject }.to change { Events::ResponseFinished.count }.by 1
+    end
+  end
 end

--- a/spec/features/answering_questions_spec.rb
+++ b/spec/features/answering_questions_spec.rb
@@ -6,7 +6,7 @@ describe 'answering questions' do
   end
 
   def expect_last_question_to_be(text, intro_text = nil)
-    within all('.question').last do
+    within(:xpath, '(//div[@class="question"])[last()]') do
       expect(page).to have_content text
       expect(page).to have_content intro_text if intro_text
     end
@@ -33,15 +33,21 @@ describe 'answering questions' do
     expect_last_question_to_be 'Vraag 2'
   end
 
-  scenario 'finishing', focus: true do
+  scenario 'finishing' do
+    expect_last_question_to_be 'Vraag 1'
+
+    # Question 1 = 'Eens' means there is a next question in VCR cassette
     answer_question 1, 'Eens'
     expect_last_question_to_be 'Vraag 2'
 
-    answer_question 1, 'Oneens'
-
     # Question 1 = 'Oneens' means done in VCR cassette
-    expect_last_question_to_be 'Vraag 2'
-    expect(page).to have_content 'asdfasdf'
+    answer_question 1, 'Oneens'
+    expect_last_question_to_be 'Vraag 1'
+    expect(page).to have_content 'Afronden'
+
+    click_on 'Afronden'
+
+    expect(page).to have_content 'Bedankt voor het invullen'
   end
 
   scenario 'starting over' do

--- a/spec/features/answering_questions_spec.rb
+++ b/spec/features/answering_questions_spec.rb
@@ -6,7 +6,7 @@ describe 'answering questions' do
   end
 
   def expect_last_question_to_be(text, intro_text = nil)
-    within '.question:last-child' do
+    within all('.question').last do
       expect(page).to have_content text
       expect(page).to have_content intro_text if intro_text
     end
@@ -33,12 +33,15 @@ describe 'answering questions' do
     expect_last_question_to_be 'Vraag 2'
   end
 
-  scenario 'changing a previously answered question' do
+  scenario 'finishing', focus: true do
     answer_question 1, 'Eens'
     expect_last_question_to_be 'Vraag 2'
 
     answer_question 1, 'Oneens'
-    expect_last_question_to_be 'Vraag 3'
+
+    # Question 1 = 'Oneens' means done in VCR cassette
+    expect_last_question_to_be 'Vraag 2'
+    expect(page).to have_content 'asdfasdf'
   end
 
   scenario 'starting over' do

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -10,7 +10,8 @@ describe 'Error reporting' do
 
       page.execute_script "$.ajax('/answers', { method: 'POST',
                                                   async: false
-                                                })"
+                                                })
+                           .fail(function() { throw new Error('test') } )"
     end
 
     # it 'reports the error to Appsignal' do


### PR DESCRIPTION
- `ResponseFinished` model, bewaar estimate en variance
- `FinishResponse` interaction met validaties:
    - response_uuid en invitation_uuid moeten bestaan
    - response moet niet eerder zijn afgerond
    - alle vragen moeten zijn beantwoord
- Link bij laatste `outcome` scherm van Screensmart om `FinishResponse` te triggeren (tekst moet tzt nog worden aangepast), hierna een redirect naar index (uitnodigings) pagina