### PR TITLE
Use requester name as invitation sender

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :test do
   gem 'rubocop'
   gem 'coffeelint'
   gem 'rspec-rails', '~> 3.4.2'
+  gem 'fabrication', '~> 2.15.2'
   gem 'rspec-collection_matchers', '~> 1.1.2'
   gem 'vcr', '~> 3.0.1'
   gem 'webmock', '~> 1.24.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.9.1)
     execjs (2.6.0)
+    fabrication (2.15.2)
     ffi (1.9.10)
     font-awesome-rails (4.5.0.1)
       railties (>= 3.2, < 5.1)
@@ -386,6 +387,7 @@ DEPENDENCIES
   coffeelint
   database_cleaner
   dotenv-rails
+  fabrication (~> 2.15.2)
   font-awesome-rails
   guard (~> 2.13.0)
   guard-bundler

--- a/app/assets/javascripts/components/InvitationForm.coffee
+++ b/app/assets/javascripts/components/InvitationForm.coffee
@@ -18,7 +18,7 @@ invitationForm = React.createClass
     dispatch Screensmart.Actions.sendInvitation(enteredValues) if @props.valid
 
   render: ->
-    { fields: { respondentEmail, requesterEmail, domainIds },
+    { fields: { respondentEmail, requesterName, requesterEmail, domainIds },
       handleSubmit,
       submitting,
       domains,
@@ -35,8 +35,15 @@ invitationForm = React.createClass
               className: if @shouldShowErrorFor 'respondentEmail' then 'invalid' else ''
               type: 'text'
               placeholder: 'e-mail respondent'
-      @renderErrorFor 'requesterEmail'
 
+      @renderErrorFor 'requesterName'
+      input \
+        merge requesterName,
+              className: if @shouldShowErrorFor 'requesterName' then 'invalid' else ''
+              type: 'text'
+              placeholder: 'uw volledige naam'
+
+      @renderErrorFor 'requesterEmail'
       input \
         merge requesterEmail,
               className: if @shouldShowErrorFor 'requesterEmail' then 'invalid' else ''
@@ -107,14 +114,17 @@ invitationForm = React.createClass
     (@props.submitFailed || @props.fields[fieldName].touched) && @props.fields[fieldName].error
 
 validate = (values) ->
+  { respondentEmail, requesterName, requesterEmail, domainIds } = values
+
   errors = {}
-  errors.respondentEmail = 'Vul een geldig e-mailadres in' unless emailValid(values.respondentEmail)
-  errors.requesterEmail = 'Vul een geldig e-mailadres in' unless emailValid(values.requesterEmail)
-  errors.domainIds = 'Kies een domein' unless !!values.domainIds
+  errors.requesterName = 'Vul uw naam in' unless requesterName != ''
+  errors.respondentEmail = 'Vul een geldig e-mailadres in' unless emailValid(respondentEmail)
+  errors.requesterEmail = 'Vul een geldig e-mailadres in' unless emailValid(requesterEmail)
+  errors.domainIds = 'Kies een domein' unless !!domainIds
   errors
 
 @InvitationForm = reduxForm(
   form: 'invitation'
-  fields: ['respondentEmail', 'requesterEmail', 'domainIds']
+  fields: ['respondentEmail', 'requesterName', 'requesterEmail', 'domainIds']
   validate: validate
 )(invitationForm)

--- a/app/commands/send_invitation.rb
+++ b/app/commands/send_invitation.rb
@@ -1,4 +1,5 @@
 class SendInvitation < ActiveInteraction::Base
+  string :requester_name
   string :requester_email
   string :respondent_email
   array :domain_ids do
@@ -6,17 +7,18 @@ class SendInvitation < ActiveInteraction::Base
   end
 
   validates :requester_email, :respondent_email, email: true
-  validates :requester_email, :respondent_email, :domain_ids, presence: true
+  validates :requester_name, :requester_email, :respondent_email, :domain_ids, presence: true
   validate :validate_domain_ids_defined_by_r_package
 
   def execute
     invitation_uuid = SecureRandom.uuid
 
-    InvitationMailer.invitation_email(requester_email: requester_email,
+    InvitationMailer.invitation_email(requester_name: requester_name,
                                       respondent_email: respondent_email,
                                       invitation_uuid: invitation_uuid).deliver_now
 
     Events::InvitationSent.create! invitation_uuid: invitation_uuid,
+                                   requester_name: requester_name,
                                    requester_email: requester_email,
                                    domain_ids: domain_ids
   end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,9 +1,13 @@
 class InvitationMailer < ApplicationMailer
-  def invitation_email(requester_email:, respondent_email:, invitation_uuid:)
-    @requester_email = requester_email
+  def invitation_email(requester_name:, respondent_email:, invitation_uuid:)
+    @requester_name = requester_name
     @link = fill_out_url(invitationUUID: invitation_uuid)
 
+    noreply_with_requester_name = Mail::Address.new self.class.default_params[:from]
+    noreply_with_requester_name.display_name = requester_name
+
     mail to: respondent_email,
+         from: noreply_with_requester_name,
          subject: 'Verzoek om vragenlijst in te vullen'
   end
 end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -3,11 +3,7 @@ class InvitationMailer < ApplicationMailer
     @requester_name = requester_name
     @link = fill_out_url(invitationUUID: invitation_uuid)
 
-    noreply_with_requester_name = Mail::Address.new self.class.default_params[:from]
-    noreply_with_requester_name.display_name = requester_name
-
     mail to: respondent_email,
-         from: noreply_with_requester_name.format,
-         subject: 'Verzoek om vragenlijst in te vullen'
+         subject: "Verzoek van #{requester_name} om vragenlijst in te vullen"
   end
 end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -7,7 +7,7 @@ class InvitationMailer < ApplicationMailer
     noreply_with_requester_name.display_name = requester_name
 
     mail to: respondent_email,
-         from: noreply_with_requester_name,
+         from: noreply_with_requester_name.format,
          subject: 'Verzoek om vragenlijst in te vullen'
   end
 end

--- a/app/models/events/invitation_sent.rb
+++ b/app/models/events/invitation_sent.rb
@@ -1,6 +1,7 @@
 module Events
   class InvitationSent < Event
-    event_attributes requester_email: :string,
+    event_attributes requester_name: :string,
+                     requester_email: :string,
                      domain_ids: :string_array
   end
 end

--- a/app/views/invitation_mailer/invitation_email.html.haml
+++ b/app/views/invitation_mailer/invitation_email.html.haml
@@ -1,6 +1,5 @@
 %p
-  Uw arts of behandelaar, #{mail_to @requester_name},
-  heeft met u afgesproken dat u een vragenlijst gaat invullen. Als dit inderdaad het geval is, klik dan op onderstaande link.
+  Uw arts of behandelaar, #{mail_to @requester_name}, heeft met u afgesproken dat u een vragenlijst gaat invullen. Als dit inderdaad het geval is, klik dan op onderstaande link.
 
 %p
   = link_to 'Vul de vragenlijst in', @link

--- a/app/views/invitation_mailer/invitation_email.html.haml
+++ b/app/views/invitation_mailer/invitation_email.html.haml
@@ -1,10 +1,9 @@
 %p
-  Uw arts of behandelaar met het e-mailadres
-  = mail_to @requester_email
+  Uw arts of behandelaar, #{mail_to @requester_name},
   heeft met u afgesproken dat u een vragenlijst gaat invullen. Als dit inderdaad het geval is, klik dan op onderstaande link.
 
 %p
-  Als dit niet het geval is, kunt u deze e-mail als niet verzonden beschouwen.
+  = link_to 'Vul de vragenlijst in', @link
 
 %p
-  = link_to 'Vul de vragenlijst in', @link
+  Als dit niet het geval is, kunt u deze e-mail als niet verzonden beschouwen.

--- a/spec/commands/accept_invitation_spec.rb
+++ b/spec/commands/accept_invitation_spec.rb
@@ -1,11 +1,7 @@
 describe AcceptInvitation do
   subject { described_class.run(params) }
 
-  let(:invitation_sent) do
-    SendInvitation.run! respondent_email: 'some@respondent.dev',
-                        requester_email: 'some@doctor.dev',
-                        domain_ids: ['POS-PQ']
-  end
+  let(:invitation_sent) { Fabricate :invitation_sent }
 
   context 'with valid parameters' do
     let(:params) { { invitation_uuid: invitation_sent.invitation_uuid } }

--- a/spec/commands/send_invitation_spec.rb
+++ b/spec/commands/send_invitation_spec.rb
@@ -1,6 +1,7 @@
 describe SendInvitation do
   let(:params) do
-    { requester_email: 'requester@example.dev',
+    { requester_name: 'Some Doctor',
+      requester_email: 'requester@example.dev',
       respondent_email: 'patient@example.dev',
       domain_ids: ['POS-PQ']
     }
@@ -26,7 +27,7 @@ describe SendInvitation do
     it 'sends the invitation' do
       allow(SecureRandom).to receive(:uuid).and_return SecureRandom.uuid # fixed value
 
-      expect(InvitationMailer).to receive(:invitation_email).with requester_email: params[:requester_email],
+      expect(InvitationMailer).to receive(:invitation_email).with requester_name: params[:requester_name],
                                                                   respondent_email: params[:respondent_email],
                                                                   invitation_uuid: SecureRandom.uuid
 
@@ -36,6 +37,13 @@ describe SendInvitation do
 
   context 'with invalid parameters' do
     subject { described_class.run(params) }
+
+    context 'requester_name is invalid' do
+      it 'has an error on requester name' do
+        params[:requester_name] = ''
+        expect(subject).to have(1).errors_on(:requester_name)
+      end
+    end
 
     context 'requester_email is invalid' do
       it 'has an error on requester email' do

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -3,6 +3,7 @@ describe InvitationsController do
     let(:valid_params) do
       {
         respondent_email: 'test@example.com',
+        requester_name: 'Some Doctor',
         requester_email: 'test2@example.com',
         domain_ids: ['POS-PQ']
       }

--- a/spec/controllers/responses_controller_spec.rb
+++ b/spec/controllers/responses_controller_spec.rb
@@ -1,9 +1,5 @@
 describe ResponsesController do
-  let!(:invitation_sent) do
-    SendInvitation.run! requester_email: 'some@doctor.dev',
-                        respondent_email: 'some@patient.dev',
-                        domain_ids: ['POS-PQ']
-  end
+  let(:invitation_sent) { Fabricate :invitation_sent }
 
   describe '#create' do
     subject { post :create, invitation_uuid: invitation_sent.invitation_uuid }

--- a/spec/fabricators/events/invitation_accepted.rb
+++ b/spec/fabricators/events/invitation_accepted.rb
@@ -1,0 +1,4 @@
+Fabricator(:invitation_accepted, from: 'Events::InvitationAccepted') do
+  invitation_uuid { Fabricate(:invitation_sent).invitation_uuid }
+  response_uuid { SecureRandom.uuid }
+end

--- a/spec/fabricators/events/invitation_sent.rb
+++ b/spec/fabricators/events/invitation_sent.rb
@@ -1,0 +1,6 @@
+Fabricator(:invitation_sent, from: 'Events::InvitationSent') do
+  invitation_uuid { SecureRandom.uuid }
+  requester_name 'Some Doctor'
+  requester_email 'some@doctor.dev'
+  domain_ids ['POS-PQ']
+end

--- a/spec/features/answering_questions_spec.rb
+++ b/spec/features/answering_questions_spec.rb
@@ -25,11 +25,7 @@ describe 'answering questions' do
     click_on 'Afronden'
   end
 
-  let(:invitation_sent) do
-    SendInvitation.run! requester_email: 'some@doctor.dev',
-                        respondent_email: 'some@patient.dev',
-                        domain_ids: ['POS-PQ']
-  end
+  let(:invitation_sent) { Fabricate :invitation_sent }
 
   before { visit fill_out_url }
 

--- a/spec/features/sending_invitations_spec.rb
+++ b/spec/features/sending_invitations_spec.rb
@@ -5,6 +5,7 @@ describe 'sending invitations' do
 
   def fill_out_all_fields
     fill_out_placeholder 'e-mail respondent', 'some@patient.dev'
+    fill_out_placeholder 'uw volledige naam', 'Some Doctor'
     fill_out_placeholder 'uw e-mail', 'some@doctor.dev'
     find('.domain-label', text: 'Positieve symptomen voor psychose').click
   end

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -15,6 +15,10 @@ describe InvitationMailer do
         expect(subject.to).to eq [params[:respondent_email]]
       end
 
+      it 'includes the requester name and email in the from field' do
+        expect(subject.header[:from].value).to eq "\"#{params[:requester_name]}\" <noreply@roqua.nl>"
+      end
+
       it 'contains a link to fill out the questionnaire' do
         expect(subject.body.encoded).to include("http://test_host/fillOut?invitationUUID=#{params[:invitation_uuid]}")
       end

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -15,8 +15,9 @@ describe InvitationMailer do
         expect(subject.to).to eq [params[:respondent_email]]
       end
 
-      it 'includes the requester name and email in the from field' do
-        expect(subject.header[:from].value).to eq "#{params[:requester_name]} <noreply@roqua.nl>"
+      it 'includes the requester name in the title' do
+        expect(subject.header[:subject].value).to eq \
+          "Verzoek van #{params[:requester_name]} om vragenlijst in te vullen"
       end
 
       it 'contains a link to fill out the questionnaire' do

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -5,7 +5,7 @@ describe InvitationMailer do
     context 'valid params' do
       let(:params) do
         {
-          requester_email: 'some@doctor.dev',
+          requester_name: 'Some Doctor',
           respondent_email: 'some@patient.dev',
           invitation_uuid: SecureRandom.uuid
         }

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -16,7 +16,7 @@ describe InvitationMailer do
       end
 
       it 'includes the requester name and email in the from field' do
-        expect(subject.header[:from].value).to eq "\"#{params[:requester_name]}\" <noreply@roqua.nl>"
+        expect(subject.header[:from].value).to eq "#{params[:requester_name]} <noreply@roqua.nl>"
       end
 
       it 'contains a link to fill out the questionnaire' do

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,9 +1,5 @@
 describe Invitation do
-  let!(:invitation_sent) do
-    SendInvitation.run! respondent_email: 'some@respondent.dev',
-                        requester_email: 'some@doctor.dev',
-                        domain_ids: ['POS-PQ']
-  end
+  let(:invitation_sent) { Fabricate :invitation_sent }
 
   let!(:invitation_accepted) do
     AcceptInvitation.run! invitation_uuid: invitation_sent.invitation_uuid

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -1,8 +1,6 @@
 describe Response do
+  let(:invitation_sent) { Fabricate :invitation_sent }
   let(:response) do
-    invitation_sent = SendInvitation.run! requester_email: 'some@doctor.dev',
-                                          respondent_email: 'some@patient.dev',
-                                          domain_ids: ['POS-PQ']
     invitation_accepted = AcceptInvitation.run! invitation_uuid: invitation_sent.invitation_uuid
     Response.find invitation_accepted.response_uuid
   end

--- a/spec/serializers/response_serializer_spec.rb
+++ b/spec/serializers/response_serializer_spec.rb
@@ -1,13 +1,5 @@
 describe ResponseSerializer do
-  let(:invitation_sent) do
-    SendInvitation.run! requester_email: 'some@doctor.dev',
-                        respondent_email: 'some@patient.dev',
-                        domain_ids: ['POS-PQ']
-  end
-
-  let(:invitation_accepted) do
-    AcceptInvitation.run! invitation_uuid: invitation_sent.invitation_uuid
-  end
+  let(:invitation_accepted) { Fabricate :invitation_accepted }
 
   subject do
     response = Response.find(invitation_accepted.response_uuid)


### PR DESCRIPTION
As the title says, plus duplicated Rspec `let` statements have been replaced by Fabricators.